### PR TITLE
Add state management

### DIFF
--- a/packages/runtime/src/__tests__/dispatcher.test.js
+++ b/packages/runtime/src/__tests__/dispatcher.test.js
@@ -106,4 +106,46 @@ describe("A command dispatcher", () => {
         expect(afterHandlers.length).toBe(0);
         expect(afterHandlers).not.toContain(handler1);
     });
+
+    it("Should display warning message in case the command has no handlers", () => {
+        const spyOnConsoleWarn = vi.spyOn(console, "warn");
+
+        dispatcher.dispatch("not-existing-command", {});
+
+        expect(spyOnConsoleWarn).toHaveBeenCalledWith(
+            "No handlers for command not-existing-command"
+        );
+    });
+
+    it("Should call all the handlers with the right payload", () => {
+        dispatcher.subscribe(command, handler1);
+        dispatcher.subscribe(command, handler2);
+
+        dispatcher.dispatch(command, { test: "test" });
+
+        expect(handler1).toHaveBeenCalledWith(payload);
+        expect(handler2).toHaveBeenCalledOnce(payload);
+    });
+
+    it("Should call afterEveryCommand handlers function after dispatch", () => {
+        const afterHandler = vi.fn();
+        dispatcher.subscribe(command, handler1);
+        dispatcher.afterEveryCommand(afterHandler);
+
+        dispatcher.dispatch(command, payload);
+
+        expect(afterHandler).toHaveBeenCalled();
+    });
+
+    it("should call all afterEveryCommand handlers even if no command handlers exist", () => {
+        const afterHandler1 = vi.fn();
+        const afterHandler2 = vi.fn();
+        dispatcher.afterEveryCommand(afterHandler1);
+        dispatcher.afterEveryCommand(afterHandler2);
+
+        dispatcher.dispatch("nonExistentCommand", { data: "test" });
+
+        expect(afterHandler1).toHaveBeenCalled();
+        expect(afterHandler2).toHaveBeenCalled();
+    });
 });

--- a/packages/runtime/src/__tests__/dispatcher.test.js
+++ b/packages/runtime/src/__tests__/dispatcher.test.js
@@ -76,4 +76,34 @@ describe("A command dispatcher", () => {
         expect(handlers).toContain(handler1);
         expect(handlers).not.toContain(handler2);
     });
+
+    it("Should register afterHandlers", () => {
+        const unregister = dispatcher.afterEveryCommand(handler1);
+        const afterHandlers = dispatcher.afterHandlers;
+
+        expect(afterHandlers.length).toBe(1);
+        expect(afterHandlers).toContain(handler1);
+    });
+
+    it("Should handle multiple handlers", () => {
+        dispatcher.afterEveryCommand(handler1);
+        dispatcher.afterEveryCommand(handler2);
+
+        const afterHandlers = dispatcher.afterHandlers;
+        expect(afterHandlers.length).toBe(2);
+        expect(afterHandlers).toContain(handler1);
+        expect(afterHandlers).toContain(handler2);
+    });
+
+    it("Should return an unregister function to remove the handler", () => {
+        const unregister = dispatcher.afterEveryCommand(handler1);
+        const afterHandlers = dispatcher.afterHandlers;
+
+        expect(afterHandlers.length).toBe(1);
+        expect(afterHandlers).toContain(handler1);
+
+        unregister();
+        expect(afterHandlers.length).toBe(0);
+        expect(afterHandlers).not.toContain(handler1);
+    });
 });

--- a/packages/runtime/src/__tests__/dispatcher.test.js
+++ b/packages/runtime/src/__tests__/dispatcher.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Dispatcher from "../dispatcher";
+
+describe("A command dispatcher", () => {
+    let dispatcher;
+    const payload = { test: "test" };
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const command = "test-event";
+
+    beforeEach(() => {
+        dispatcher = new Dispatcher();
+    });
+
+    it("Should add a handler for a command", () => {
+        dispatcher.subscribe(command, handler1);
+
+        const handlers = dispatcher.subs.get(command);
+        expect(handlers).toContain(handler1);
+    });
+
+    it("Should return empty function if handler already exists", () => {
+        const unsubscribe1 = dispatcher.subscribe(command, handler1);
+        const unsubscribe2 = dispatcher.subscribe(command, handler1);
+
+        expect(unsubscribe1).not.toBe(unsubscribe2);
+        expect(unsubscribe2.toString()).toBe("() => {}");
+    });
+
+    it("Should remove a handler when the unubscribe function is called", () => {
+        const unsubscribe = dispatcher.subscribe(command, handler1);
+
+        let handlers = dispatcher.subs.get(command);
+        expect(handlers).toContain(handler1);
+
+        unsubscribe();
+
+        handlers = dispatcher.subs.get(command);
+        expect(handlers).not.toContain(handler1);
+    });
+
+    it("Should not anything if the same unubscribe is called twice", () => {
+        const unsubscribe = dispatcher.subscribe(command, handler1);
+        const handlers = dispatcher.subs.get(command);
+
+        expect(handlers).toContain(handler1);
+
+        unsubscribe();
+        unsubscribe();
+
+        expect(handlers.length).toBe(0);
+        expect(handlers).not.toContain(handler1);
+    });
+
+    it("Should handle multiple handlers for the same command", () => {
+        dispatcher.subscribe(command, handler1);
+        dispatcher.subscribe(command, handler2);
+
+        const handlers = dispatcher.subs.get(command);
+        expect(handlers.length).toBe(2);
+        expect(handlers).toContain(handler1);
+        expect(handlers).toContain(handler2);
+    });
+
+    it("Should remove the correct handler when multiple handlers are subscribed", () => {
+        dispatcher.subscribe(command, handler1);
+        const unsubscribe2 = dispatcher.subscribe(command, handler2);
+
+        let handlers = dispatcher.subs.get(command);
+        expect(handlers.length).toBe(2);
+        expect(handlers).toContain(handler1);
+        expect(handlers).toContain(handler2);
+
+        unsubscribe2();
+        handlers = dispatcher.subs.get(command);
+        expect(handlers).toContain(handler1);
+        expect(handlers).not.toContain(handler2);
+    });
+});

--- a/packages/runtime/src/app.js
+++ b/packages/runtime/src/app.js
@@ -1,0 +1,44 @@
+import { mountDom } from "./mountDom";
+import { destroyDom } from "./destroyDom";
+import Dispatcher from "./dispatcher";
+
+function createApp({ state = {}, view, reducers = {} }) {
+    let parentEl = null;
+    let vdom = null;
+
+    const dispatcher = new Dispatcher();
+    const subscriptions = [dispatcher.afterEveryCommand(renderApp)];
+
+    for (const actionName in reducers) {
+        const reducer = reducers[actionName];
+
+        const subs = dispatcher.subscribe(actionName, (payload) => {
+            state = reducer(state, payload);
+        });
+        subscriptions.push(subs);
+    }
+
+    function renderApp() {
+        if (vdom) {
+            destroyDom(vdom);
+        }
+        vdom = view(state, emit);
+        mountDom(vdom, parentEl);
+    }
+
+    function emit(eventName, payload) {
+        dispatcher.dispatch(eventName, payload);
+    }
+
+    return {
+        mount: function (_parentEl) {
+            parentEl = _parentEl;
+            renderApp();
+        },
+        unmount: function () {
+            destroyDom(vdom);
+            vdom = null;
+            subscriptions.forEach((unsubscribe) => unsubscribe());
+        },
+    };
+}

--- a/packages/runtime/src/dispatcher.js
+++ b/packages/runtime/src/dispatcher.js
@@ -1,5 +1,6 @@
 export default class Dispatcher {
     #subs = new Map();
+    #afterHandlers = [];
 
     subscribe(commandName, handler) {
         if (!this.#subs.has(commandName)) {
@@ -24,5 +25,18 @@ export default class Dispatcher {
         return this.#subs;
     }
 
+    get afterHandlers() {
+        return this.#afterHandlers;
+    }
+
     dispatch(commandName, payload) {}
+
+    afterEveryCommand(handler) {
+        this.#afterHandlers.push(handler);
+
+        return () => {
+            const idx = this.#afterHandlers.indexOf(handler);
+            this.#afterHandlers.splice(idx, 1);
+        };
+    }
 }

--- a/packages/runtime/src/dispatcher.js
+++ b/packages/runtime/src/dispatcher.js
@@ -1,0 +1,28 @@
+export default class Dispatcher {
+    #subs = new Map();
+
+    subscribe(commandName, handler) {
+        if (!this.#subs.has(commandName)) {
+            this.#subs.set(commandName, []);
+        }
+
+        const handlers = this.#subs.get(commandName);
+        if (handlers.includes(handler)) {
+            // nothing to un-register
+            return () => {};
+        }
+
+        handlers.push(handler);
+
+        return () => {
+            const idx = handlers.indexOf(handler);
+            handlers.splice(idx, 1);
+        };
+    }
+
+    get subs() {
+        return this.#subs;
+    }
+
+    dispatch(commandName, payload) {}
+}

--- a/packages/runtime/src/dispatcher.js
+++ b/packages/runtime/src/dispatcher.js
@@ -29,7 +29,14 @@ export default class Dispatcher {
         return this.#afterHandlers;
     }
 
-    dispatch(commandName, payload) {}
+    dispatch(commandName, payload) {
+        if (!this.#subs.has(commandName)) {
+            console.warn(`No handlers for command ${commandName}`);
+        } else {
+            this.#subs.get(commandName).forEach((handler) => handler(payload));
+        }
+        this.#afterHandlers.forEach((handler) => handler());
+    }
 
     afterEveryCommand(handler) {
         this.#afterHandlers.push(handler);


### PR DESCRIPTION
## CONTEXT
Add state management

## CHANGES
- add implementation for subscribe function
- add unit tests for subscribe class function
- add implementation for afterEveryCommand function
- add unit tests for afterEveryCommmand function
- add implementation for dispatch function
- add unit tests
- implement createApp function that links together the state manager and the renderer
